### PR TITLE
docs: fix dimension typo in MatrixMultiplyKernel comments

### DIFF
--- a/src/combine.cu
+++ b/src/combine.cu
@@ -414,7 +414,7 @@ __global__ void MatrixMultiplyKernel(
    * - Only read each cell in a and b once.
    * - Only write to global memory once per kernel.
    * There is guarantee that a_shape[0] == b_shape[0], a_shape[2] == b_shape[1],
-   * and out_shape[0] == a_shape[0], out_shape[1] == b_shape[1]
+   * and out_shape[0] == a_shape[0], out_shape[1] == a_shape[1], out_shape[2] == b_shape[2].
    *
    * Args:
    *   out: compact 1D array of size batch_size x m x p to write the output to


### PR DESCRIPTION
Hi! I noticed a typo in the MatrixMultiplyKernel requirements. For [M,N]×[N,P], the output rows should be M (a_shape[1]), not b_shape[1]. Corrected the comment to prevent confusion.