### PR TITLE
Fix typo of function header in combine.cu

### DIFF
--- a/src/combine.cu
+++ b/src/combine.cu
@@ -200,9 +200,8 @@ __device__ void broadcast_index(const int *big_index, const int *big_shape, cons
    *    big_index: multidimensional index of bigger tensor
    *    big_shape: tensor shape of bigger tensor
    *    shape: tensor shape of smaller tensor
-   *    nums_big_dims: number of dimensions in bigger tensor
    *    out_index: multidimensional index of smaller tensor
-   *    nums_big_dims: number of dimensions in bigger tensor
+   *    num_dims_big: number of dimensions in bigger tensor
    *    num_dims: number of dimensions in smaller tensor
    *
    * Returns:


### PR DESCRIPTION
Original function header is written badly:
/**
   * Convert a big_index into big_shape to a smaller out_index into shape following broadcasting rules.
   * In this case it may be larger or with more dimensions than the shape given.
   * Additional dimensions may need to be mapped to 0 or removed.
   *
   * Args:
   *    big_index: multidimensional index of bigger tensor
   *    big_shape: tensor shape of bigger tensor
   *    shape: tensor shape of smaller tensor
   *    nums_big_dims: number of dimensions in bigger tensor
   *    out_index: multidimensional index of smaller tensor
   *    nums_big_dims: number of dimensions in bigger tensor
   *    num_dims: number of dimensions in smaller tensor
   *
   * Returns:
   *    None (Fills in out_index)
   */
   there are two "nums_big_dims" and none of them are actual parameter "num_dims_big"
   fixed that.