### PR TITLE
Fixed indexing in tiled matrix mul pseudo-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ __global__ void mm(float A[N][N], float B[N][N], float C[N][N]) {
     int j = blockIdx.y * blockDim.y + threadIdx.y;
     for (int ks = 0; ks < N; ks += L) {
         sA[:, :] = A[i:i+S, ks:ks+L];
-        sB[:, :] = B[i:i+S, ks:ks+L];
+        sB[:, :] = B[ks:ks+L, j:j+S]
         __syncthreads();
         for (int ki = 0; ki < L; ++kk) {
             tC[:] += sA[:][ki] * sB[ki][:];


### PR DESCRIPTION
Fixed incorrect indexing for matrix B in the shared-memory tiling pseudocode (line 286 in README.md).