### PR TITLE
[FIX] Updated Figure syntax for rendering in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ __global__ void reduceKernel(scalar_t* out, ...){
 
 A simple way to parallel the reduce function is to have every reduced element in the output calculated individually in each block. The basic idea of ReduceSum is shown in Figure 1. In each block, it is important to think about how to calculate the step across the data to be reduced based on `reduce_dim` and `strides`.
 
-<figure markdown="span"> ![image title](hw1/reduce.jpg) <figcaption>Figure 1: Basic idea of reduce add function.</figcaption> </figure>
+![Figure 1: Basic idea of reduce add function.](hw1/reduce.jpg)
 
 #### Hints - Optimized Reduction (Optional)
 
@@ -208,7 +208,7 @@ __global__ void reduce0(int *g_idata, int *g_odata) {
 }
 ```
 
-<figure markdown="span"> ![Image title](hw1/reduction.png){width="600"} <figcaption>Figure 2: Reduction<sup>1</sup>.</figcaption> </figure>
+![Figure 2: Reduction<sup>1</sup>.](hw1/reduction.png)
 
 ### Part B: Integrate Reduce Operation (5 points)
 
@@ -269,7 +269,7 @@ __global__ void mm(float A[N][N], float B[N][N], float C[N][N]) {
 }
 ```
 
-<figure markdown="span"> ![Image title](hw1/simple_parallel.png){width="300"} <figcaption>Figure 3: Simple parallelization.</figcaption> </figure>
+![Figure 3: Simple parallelization.](hw1/simple_parallel.png)
 
 #### Hints - Shared Memory Tiling (Optional)
 
@@ -294,7 +294,7 @@ __global__ void mm(float A[N][N], float B[N][N], float C[N][N]) {
 }
 ```
 
-<figure markdown="span"> ![Image title](hw1/block_level_parallel.png){width="300"} <figcaption>Figure 4: Shared memory tiling.</figcaption> </figure>
+![Figure 4: Shared memory tiling.](hw1/block_level_parallel.png)
 
 ### Part B: Integrate Matrix Multiplication (5 points)
 


### PR DESCRIPTION
Figures were not rendering properly in the README. Fixed their format to standard markdown for rendering properly.